### PR TITLE
Moved setting of localStorage from loginConfirmed to $http.success()

### DIFF
--- a/www/js/services.js
+++ b/www/js/services.js
@@ -6,6 +6,7 @@ angular.module('ionic-http-auth.services', ['http-auth-interceptor'])
       .success(function (data, status, headers, config) {
 
     	$http.defaults.headers.common.Authorization = data.authorizationToken;  // Step 1
+      localStorageService.set('authorizationToken', data.authorizationToken);
         
     	// Need to inform the http-auth-interceptor that
         // the user has logged in successfully.  To do this, we pass in a function that
@@ -14,7 +15,6 @@ angular.module('ionic-http-auth.services', ['http-auth-interceptor'])
         // authorization token placed in the header
         authService.loginConfirmed(data, function(config) {  // Step 2 & 3
           config.headers.Authorization = data.authorizationToken;
-          localStorageService.set('authorizationToken', data.authorizationToken);
           return config;
         });
       })


### PR DESCRIPTION
The configUpdater function can be executed multiple times if the http-auth buffer contains multiple requests. It's a better idea to set the local storage value outside of it.
